### PR TITLE
Rebase Linux runner to Ubuntu 18.04 for access to the i686 toolchain 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             {
               os-cfg: linux_x86_64,
               runner: ubuntu-latest,
-              container: "ghcr.io/ryanhir/toolchain-builder:xenial",
+              container: "ghcr.io/ryanhir/toolchain-builder:bionic",
             },
             {
               os-cfg: windows_x86_64,
@@ -49,6 +49,21 @@ jobs:
               container: "",
             }
           ]
+        include:
+          - host:
+              os-cfg: linux_i686
+              runner: ubuntu-latest
+              container: ghcr.io/ryanhir/toolchain-builder:bionic
+            target:
+              os: raspi-buster
+              port: armhf
+          - host:
+              os-cfg: linux_i686
+              runner: ubuntu-latest
+              container: ghcr.io/ryanhir/toolchain-builder:bionic
+            target:
+              os: raspi-bullseye
+              port: armhf
     name: Build ${{ matrix.target.os }}-${{ matrix.target.port }} for ${{ matrix.host.os-cfg }}
     runs-on: ${{ matrix.host.runner }}
     container: ${{ matrix.host.container }}

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 
 ### Tier 1
 
-| OS | Arch | Minimum Supported Release |
-| - | - | - |
-| Windows | x86_64 | Windows 7 |
-| Linux | x86_64 | Ubuntu 16.04 |
-| Mac | x86_64 | macOS 10.9 |
+| OS | Arch | Minimum Supported Release | Note |
+| - | - | - | - |
+| Windows | x86_64 | Windows 7 | - |
+| Linux | i686 | Ubuntu 18.04 | Only for Raspberry Pi OS |
+| Linux | x86_64 | Ubuntu 18.04 | - |
+| Mac | x86_64 | macOS 10.9 | - |
 
 ### Tier 2
 
@@ -22,8 +23,8 @@ NOTE: Tier 2 is not supported, but pull requests are accepted.
 | OS | Arch | Minimum Supported Release |
 | - | - | - |
 | Windows | i686 | Windows 7 |
-| Linux | armv7 | Ubuntu 16.04 |
-| Linux | arm64 | Ubuntu 16.04 |
+| Linux | armv7 | Ubuntu 18.04 |
+| Linux | arm64 | Ubuntu 18.04 |
 | Linux | i686 | Ubuntu 16.04 |
 | Mac | arm64 | macOS 11.0 |
 | Mac | Universal | - |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | OS | Arch | Minimum Supported Release | Note |
 | - | - | - | - |
 | Windows | x86_64 | Windows 7 | - |
-| Linux | i686 | Ubuntu 18.04 | Only for Raspberry Pi OS |
+| Linux | i686 | Ubuntu 18.04 | Only for Raspberry Pi OS targets |
 | Linux | x86_64 | Ubuntu 18.04 | - |
 | Mac | x86_64 | macOS 10.9 | - |
 
@@ -25,7 +25,7 @@ NOTE: Tier 2 is not supported, but pull requests are accepted.
 | Windows | i686 | Windows 7 |
 | Linux | armv7 | Ubuntu 18.04 |
 | Linux | arm64 | Ubuntu 18.04 |
-| Linux | i686 | Ubuntu 16.04 |
+| Linux | i686 | Ubuntu 18.04 |
 | Mac | arm64 | macOS 11.0 |
 | Mac | Universal | - |
 

--- a/hosts/linux_i686.env
+++ b/hosts/linux_i686.env
@@ -1,3 +1,4 @@
 export WPI_HOST_NAME=Linux
 export WPI_HOST_TUPLE=i686-linux-gnu
 export WPI_HOST_PREFIX=/opt/frc
+export PREBUILD_CANADIAN=true

--- a/res/Dockerfile
+++ b/res/Dockerfile
@@ -1,6 +1,4 @@
-ARG ARCH=amd64
-ARG RELEASE=xenial
-FROM docker.io/${ARCH}/ubuntu:${RELEASE}
+FROM docker.io/ubuntu:bionic
 LABEL org.opencontainers.image.source "https://github.com/RyanHir/toolchain-builder"
 ENV TZ=UTC
 

--- a/res/Makefile
+++ b/res/Makefile
@@ -2,34 +2,9 @@ export DOCKER_BUILDKIT=0
 TAG=ghcr.io/ryanhir/toolchain-builder
 
 .PHONY: all
-all: manifest
-
-# Cannot be a part of the Ubuntu Ports
-ARCH_LIST=amd64 i386
-
-manifest: manifest-bionic manifest-xenial
-	/bin/true
-
-manifest-%: $(foreach arch,${ARCH_LIST},%/build-${arch})
-	docker manifest create ${TAG}:$* \
-		$(foreach arch,${ARCH_LIST},--amend ${TAG}:$*-${arch})
-	docker manifest push ${TAG}:$*
-
-
-bionic/build-%:
+all:
 	docker build \
-		-t ${TAG}:bionic-$* \
-		--platform linux/$* \
-		--build-arg ARCH=$* \
-		--build-arg RELEASE=bionic \
+		-t ${TAG}:bionic \
+		--platform linux/amd64 \
 		.
-	docker push ${TAG}:bionic-$*
-
-xenial/build-%:
-	docker build \
-		-t ${TAG}:xenial-$* \
-		--platform linux/$* \
-		--build-arg ARCH=$* \
-		--build-arg RELEASE=xenial \
-		.
-	docker push ${TAG}:xenial-$*
+	docker push ${TAG}:bionic

--- a/res/src/setup.sh
+++ b/res/src/setup.sh
@@ -43,6 +43,8 @@ apt-get install -y \
     git \
     mingw-w64 \
     m4 \
+    python3 \
+    python3-pip \
     rsync \
     sudo \
     texinfo \

--- a/res/src/setup.sh
+++ b/res/src/setup.sh
@@ -1,25 +1,23 @@
 #! /bin/sh
 
-PYVER="python3.7"
 set -ex
 
-ARCH="$(dpkg --print-architecture)"
 DISTRO="$(grep 'DISTRIB_CODENAME' /etc/lsb-release | sed 's/.*=//g')"
-SOURCES="main restricted universe multiverse"
+SOURCES="main universe"
 MAIN_REPO="http://us.archive.ubuntu.com/ubuntu/"
 PORT_REPO="http://us.ports.ubuntu.com/ubuntu-ports/"
 
 cat << EOF > /etc/apt/sources.list
-deb [arch=${ARCH}] ${MAIN_REPO} ${DISTRO} ${SOURCES}
-deb [arch=${ARCH}] ${MAIN_REPO} ${DISTRO}-security ${SOURCES}
-deb [arch=${ARCH}] ${MAIN_REPO} ${DISTRO}-updates ${SOURCES}
+deb [arch=amd64,i386] ${MAIN_REPO} ${DISTRO} ${SOURCES}
+deb [arch=amd64,i386] ${MAIN_REPO} ${DISTRO}-security ${SOURCES}
+deb [arch=amd64,i386] ${MAIN_REPO} ${DISTRO}-updates ${SOURCES}
 
 deb [arch=arm64,armhf] ${PORT_REPO} ${DISTRO} ${SOURCES}
 deb [arch=arm64,armhf] ${PORT_REPO} ${DISTRO}-security ${SOURCES}
 deb [arch=arm64,armhf] ${PORT_REPO} ${DISTRO}-updates ${SOURCES}
 EOF
 
-# arm
+dpkg --add-architecture i386
 dpkg --add-architecture arm64
 dpkg --add-architecture armhf
 
@@ -40,30 +38,20 @@ apt-get install -y \
     file \
     flex \
     gawk \
+    gcc-i686-linux-gnu \
+    g++-i686-linux-gnu \
     git \
     mingw-w64 \
     m4 \
-    ninja-build \
     rsync \
-    software-properties-common \
     sudo \
     texinfo \
     wget \
     zip \
-    zlib1g-dev:${ARCH} \
+    zlib1g-dev:i386 \
+    zlib1g-dev:amd64 \
     zlib1g-dev:armhf \
     zlib1g-dev:arm64
-
-# Install python3.7
-add-apt-repository -y ppa:deadsnakes/ppa
-apt-get update
-apt-get install -y "$PYVER"
-update-alternatives --install /usr/bin/python3 python3 /usr/bin/"$PYVER" 0
-
-# Setup pip with python3.7
-wget https://bootstrap.pypa.io/get-pip.py
-python3 get-pip.py
-rm get-pip.py
 
 apt-get autoclean
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Bumps Linux requirements to Ubuntu 18.04. Enables building of i686 hosted toolchains for the Raspberry Pi in CI.