### PR TITLE
Drop z suffix from ARM arch config to match with raspbian repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ NOTE: Tier 2 is not supported, but pull requests are accepted.
 | - | - | - |
 | ARMv7 (softfp) | N.I. Linux (roboRIO) Sumo | GCC 7.3
 | ARMv7 (softfp) | N.I. Linux (roboRIO) Hardknott | GCC 10.2
-| ARMv6z | Raspberry Pi OS 10 | GCC 8.3
-| ARMv6z | Raspberry Pi OS 11 | GCC 10.2
+| ARMv6 | Raspberry Pi OS 10 | GCC 8.3
+| ARMv6 | Raspberry Pi OS 11 | GCC 10.2
 | ARMv7 | Debian/Raspberry Pi OS 10 | GCC 8.3
 | ARMv7 | Debian/Raspberry Pi OS 11 | GCC 10.2
 | ARMv7 | Ubuntu 18.04 | GCC 7.3

--- a/targets/raspi-bullseye/info.armhf.env
+++ b/targets/raspi-bullseye/info.armhf.env
@@ -2,8 +2,8 @@
 
 export TARGET_CPU=""
 export TARGET_FPU="vfp"
-export TARGET_ARCH="armv6z"
+export TARGET_ARCH="armv6"
 export TARGET_FLOAT="hard"
 export TARGET_TUPLE="arm-linux-gnueabihf"
 export TARGET_SPECS='%{save-temps: -fverbose-asm} %{funwind-tables|fno-unwind-tables|mabi=*|ffreestanding|nostdlib:;:-funwind-tables}'
-export TARGET_PREFIX="armv6z-bullseye-linux-gnueabihf-"
+export TARGET_PREFIX="armv6-bullseye-linux-gnueabihf-"

--- a/targets/raspi-buster/info.armhf.env
+++ b/targets/raspi-buster/info.armhf.env
@@ -2,8 +2,8 @@
 
 export TARGET_CPU=""
 export TARGET_FPU="vfp"
-export TARGET_ARCH="armv6z"
+export TARGET_ARCH="armv6"
 export TARGET_FLOAT="hard"
 export TARGET_TUPLE="arm-linux-gnueabihf"
 export TARGET_SPECS='%{save-temps: -fverbose-asm} %{funwind-tables|fno-unwind-tables|mabi=*|ffreestanding|nostdlib:;:-funwind-tables}'
-export TARGET_PREFIX="armv6z-buster-linux-gnueabihf-"
+export TARGET_PREFIX="armv6-buster-linux-gnueabihf-"


### PR DESCRIPTION
Raspbian uses `-march=armv6 -mfpu=vfp -mfloat-abi=hard` per [the raspbian FAQ](https://raspbian.org/RaspbianFAQ#What_compilation_options_should_be_set_Raspbian_code.3F)

The end user can always enable optimizations for their config.