### PR TITLE
Fix CMAKE_SYSTEM_PROCESSOR for aarch64 compilers

### DIFF
--- a/makes/src/91-cmake-cfg.sh
+++ b/makes/src/91-cmake-cfg.sh
@@ -24,8 +24,11 @@ mkdir -p "${BUILD_DIR}/cmake-install/${WPI_HOST_PREFIX}"
 xcd "${BUILD_DIR}/cmake-install/${WPI_HOST_PREFIX}"
 
 case "${TARGET_TUPLE}" in
-arm* | aarch64*)
+arm*)
     PROCESSOR=arm
+    ;;
+arach64*)
+    PROCESSOR=aarch64
     ;;
 x86_64*)
     PROCESSOR=AMD64

--- a/makes/src/91-cmake-cfg.sh
+++ b/makes/src/91-cmake-cfg.sh
@@ -27,7 +27,7 @@ case "${TARGET_TUPLE}" in
 arm*)
     PROCESSOR=arm
     ;;
-arach64*)
+aarch64*)
     PROCESSOR=aarch64
     ;;
 x86_64*)


### PR DESCRIPTION
It needs to be `aarch64`, since that's what `uname -m` prints on those systems.