### PR TITLE
ci: reduce space used by Canadian host toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,10 +444,9 @@ jobs:
         run: |
           cd cross
           find . -type f
-          tar xzf *.tgz
-          cd raspi-bookworm
           rm -rf /usr/aarch64-linux-gnu /usr/arm-linux-gnueabihf
-          cp -Rp * /usr
+          tar xzf *.tgz --strip-components 2 -C /usr/
+          rm -rf *
       - name: Build
         run: |
           make frontend
@@ -510,10 +509,9 @@ jobs:
         run: |
           cd cross
           find . -type f
-          tar xzf *.tgz
-          cd bookworm
           rm -rf /usr/aarch64-linux-gnu /usr/arm-linux-gnueabihf
-          cp -Rp * /usr
+          tar xzf *.tgz --strip-components 2 -C /usr/
+          rm -rf *
       - name: Build
         run: |
           make frontend
@@ -548,10 +546,9 @@ jobs:
         run: |
           cd cross
           find . -type f
-          tar xzf *.tgz
-          cd bookworm
           rm -rf /usr/aarch64-linux-gnu /usr/arm-linux-gnueabihf
-          cp -Rp * /usr
+          tar xzf *.tgz --strip-components 2 -C /usr/
+          rm -rf *
       - name: Build
         run: |
           make frontend

--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -139,10 +139,9 @@ jobs:
         run: |
           cd cross
           find . -type f
-          tar xzf *.tgz
-          cd {{ task.host.os }}
           rm -rf /usr/aarch64-linux-gnu /usr/arm-linux-gnueabihf
-          cp -Rp * /usr
+          tar xzf *.tgz --strip-components 2 -C /usr/
+          rm -rf *
 {%- endif %}
       - name: Build
         run: |


### PR DESCRIPTION
Extract tarball directly to /usr and then delete the archive. By removing the extra extracted copy of the toolchain and the original archive we save ~ 3gb