### PR TITLE
Remove /usr/lib/dri

### DIFF
--- a/res/opensysroot/opensysroot/workenvironment.py
+++ b/res/opensysroot/opensysroot/workenvironment.py
@@ -24,6 +24,7 @@ TO_DELETE = [
     "usr/lib/bfd-plugins",
     "usr/lib/compat-ld",
     "usr/lib/gold-ld",
+    "usr/lib/{tuple}/dri",
     "usr/libexec"
 ]
 


### PR DESCRIPTION
The files inside are display drivers, so there's no need to link to them. Also, there's 43 of those files, and they're all the same 43 MB file, so it explodes the size quite fast.