### PR TITLE
Skip redundant downloads

### DIFF
--- a/makes/src/10-sysroot.sh
+++ b/makes/src/10-sysroot.sh
@@ -24,9 +24,9 @@ FUNC_ONLY=true
 # shellcheck source=./common.sh
 source "$(dirname "$0")/common.sh"
 
-rm -rf "${BUILD_DIR}/sysroot-build"
+rm -rf "${BUILD_DIR}/sysroot-build/${TARGET_DISTRO}/${TARGET_DISTRO_RELEASE}/${TARGET_PORT}/sysroot"
 rm -rf "${BUILD_DIR}/sysroot-install"
-mkdir "${BUILD_DIR}/sysroot-build"
+mkdir -p "${BUILD_DIR}/sysroot-build"
 mkdir -p "${BUILD_DIR}/sysroot-install/${TARGET_TUPLE}/sysroot"
 
 ARGS=(

--- a/makes/src/11-sources.sh
+++ b/makes/src/11-sources.sh
@@ -19,11 +19,12 @@
 # <http://www.gnu.org/licenses/>.
 
 # shellcheck disable=SC2010
-
-FUNC_ONLY=true
-
 # shellcheck source=./common.sh
 source "$(dirname "$0")/common.sh"
+
+if is_step_backend && ! is_lib_rebuild_required; then
+    exit 0
+fi
 
 function download_or_die() {
     echo "[INFO] Downloading from $1"
@@ -34,10 +35,10 @@ function download_or_die() {
 
 function download_extract() {
     download_or_die "$1"
+    echo "[INFO] Extracting ${1/*\//}"
     tar -xf "${1/*\//}" || die "${1/*\//} extract failed"
 }
 
-rm -rf "${DOWNLOAD_DIR}"
 mkdir -p "${DOWNLOAD_DIR}"
 
 xpushd "${DOWNLOAD_DIR}"

--- a/makes/src/12-patches.sh
+++ b/makes/src/12-patches.sh
@@ -23,6 +23,10 @@
 # shellcheck source=./common.sh
 source "$(dirname "$0")/common.sh"
 
+if is_step_backend && ! is_lib_rebuild_required; then
+    exit 0
+fi
+
 function patch_or_die() {
     if ! [ -e "${1}" ]; then
         die "${1} does not exist"

--- a/makes/src/common.sh
+++ b/makes/src/common.sh
@@ -26,6 +26,10 @@ export FFLAGS_FOR_TARGET="-g -O2"
 export CFLAGS_FOR_TARGET="-g -O2"
 export CXXFLAGS_FOR_TARGET="-g -O2"
 
+BUILD_TUPLE="${WPI_BUILD_TUPLE}"
+HOST_TUPLE="${WPI_HOST_TUPLE}"
+SYSROOT_PATH="${WPI_HOST_PREFIX}/${TARGET_TUPLE}/sysroot"
+SYSROOT_BUILD_PATH="$BUILD_DIR/sysroot-install/${TARGET_TUPLE}/sysroot"
 source "$(dirname "$0")/utils/funcs.sh"
 
 if [ "${FUNC_ONLY}" = "true" ]; then
@@ -39,10 +43,6 @@ env_exists V_GCC
 env_exists WPI_HOST_PREFIX
 env_exists DOWNLOAD_DIR
 
-BUILD_TUPLE="${WPI_BUILD_TUPLE}"
-HOST_TUPLE="${WPI_HOST_TUPLE}"
-SYSROOT_PATH="${WPI_HOST_PREFIX}/${TARGET_TUPLE}/sysroot"
-SYSROOT_BUILD_PATH="$BUILD_DIR/sysroot-install/${TARGET_TUPLE}/sysroot"
 
 CONFIGURE_COMMON_LITE=(
     "--build=${BUILD_TUPLE}"


### PR DESCRIPTION
This allows the caching logic in opensysroot to actually be used and avoids hitting mirrors more than necessary. Closes #86.